### PR TITLE
extract_toc: do not populate article.toc with empty list

### DIFF
--- a/extract_toc/extract_toc.py
+++ b/extract_toc/extract_toc.py
@@ -29,6 +29,8 @@ def extract_toc(content):
         toc = soup.find('div', class_='toc')
         if toc:
             toc.extract()
+            if len(toc.find_next('ul').find_all('li')) == 0:
+                toc = None
 
     # default reStructuredText reader
     if not toc and readers.RstReader.enabled and extension in readers.RstReader.file_extensions:


### PR DESCRIPTION
In Markdown, if user adds `[TOC]` and the article does not
contain any headings, then `article.toc` ends up getting empty list.

```
<div><ul></ul></div>
```

This patch fixes this issue.

Related to https://github.com/Pelican-Elegant/elegant/issues/278