### PR TITLE
filetime_from_git: enable searching parent directory

### DIFF
--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -36,7 +36,7 @@ class _GitWrapperCommon(object):
             HOME=os.getcwd(),
             XDG_CONFIG_HOME=os.getcwd()
         )
-        self.repo = Repo(os.path.abspath('.'))
+        self.repo = Repo(os.path.abspath("."), search_parent_directories=True)
 
     def is_file_managed_by_git(self, path):
         '''


### PR DESCRIPTION
If your Pelican content is in a sub-directory then this plugin used to
fail. 

This patch fixes the issue.